### PR TITLE
Renamed SSL and TLS to what they actually are

### DIFF
--- a/easy-wp-smtp/easy-wp-smtp-admin-menu.php
+++ b/easy-wp-smtp/easy-wp-smtp-admin-menu.php
@@ -302,9 +302,9 @@ function swpsmtp_settings() {
     				<th><?php _e( 'Type of Encryption', 'easy-wp-smtp' ); ?></th>
     				<td>
     				    <label for="swpsmtp_smtp_type_encryption_1"><input type="radio" id="swpsmtp_smtp_type_encryption_1" name="swpsmtp_smtp_type_encryption" value='none' <?php if ( isset( $swpsmtp_options[ 'smtp_settings' ][ 'type_encryption' ] ) && 'none' == $swpsmtp_options[ 'smtp_settings' ][ 'type_encryption' ] ) echo 'checked="checked"'; ?> /> <?php _e( 'None', 'easy-wp-smtp' ); ?></label>
-    				    <label for="swpsmtp_smtp_type_encryption_2"><input type="radio" id="swpsmtp_smtp_type_encryption_2" name="swpsmtp_smtp_type_encryption" value='ssl' <?php if ( isset( $swpsmtp_options[ 'smtp_settings' ][ 'type_encryption' ] ) && 'ssl' == $swpsmtp_options[ 'smtp_settings' ][ 'type_encryption' ] ) echo 'checked="checked"'; ?> /> <?php _e( 'SSL', 'easy-wp-smtp' ); ?></label>
-    				    <label for="swpsmtp_smtp_type_encryption_3"><input type="radio" id="swpsmtp_smtp_type_encryption_3" name="swpsmtp_smtp_type_encryption" value='tls' <?php if ( isset( $swpsmtp_options[ 'smtp_settings' ][ 'type_encryption' ] ) && 'tls' == $swpsmtp_options[ 'smtp_settings' ][ 'type_encryption' ] ) echo 'checked="checked"'; ?> /> <?php _e( 'TLS', 'easy-wp-smtp' ); ?></label><br />
-    				    <p class="description"><?php _e( "For most servers SSL is the recommended option", 'easy-wp-smtp' ); ?></p>
+    				    <label for="swpsmtp_smtp_type_encryption_2"><input type="radio" id="swpsmtp_smtp_type_encryption_2" name="swpsmtp_smtp_type_encryption" value='ssl' <?php if ( isset( $swpsmtp_options[ 'smtp_settings' ][ 'type_encryption' ] ) && 'ssl' == $swpsmtp_options[ 'smtp_settings' ][ 'type_encryption' ] ) echo 'checked="checked"'; ?> /> <?php _e( 'SSL/TLS', 'easy-wp-smtp' ); ?></label>
+    				    <label for="swpsmtp_smtp_type_encryption_3"><input type="radio" id="swpsmtp_smtp_type_encryption_3" name="swpsmtp_smtp_type_encryption" value='tls' <?php if ( isset( $swpsmtp_options[ 'smtp_settings' ][ 'type_encryption' ] ) && 'tls' == $swpsmtp_options[ 'smtp_settings' ][ 'type_encryption' ] ) echo 'checked="checked"'; ?> /> <?php _e( 'STARTTLS', 'easy-wp-smtp' ); ?></label><br />
+    				    <p class="description"><?php _e( "For most servers SSL/TLS is the recommended option", 'easy-wp-smtp' ); ?></p>
     				</td>
     			    </tr>
     			    <tr class="ad_opt swpsmtp_smtp_options">


### PR DESCRIPTION
Hello,

Title is self-explicit, I won't re-explain everything here, please see:
https://wordpress.org/support/topic/mistake-ssl-and-tls-should-be-called-ssl-tls-and-starttls/
https://www.limilabs.com/blog/ssl-vs-tls-vs-starttls-stls

You can admire how beautiful the result of this PR would be:
![starttls](https://user-images.githubusercontent.com/8805941/43367777-e21c94ec-9352-11e8-9bb7-446548be5c7c.PNG)

In the long run, it would be nice to rename your PHP variables as well for clarity, I would gladly do it if I spoke PHP but my thing (as a sysadmin) is Bash, so I'm gonna have to leave it up to you for now otherwise I would probably mess up everything!

Best regards and cheers up for the creator of one of the most solid WP plugins I've ever been using.